### PR TITLE
Fix: Load JS applications in calendar and reminders pages

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -10,6 +10,6 @@
 <body>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="calendar-root"></div>
-
+  <script type="module" src="/dist/calendarApp.js"></script>
 </body>
 </html>

--- a/reminders.html
+++ b/reminders.html
@@ -10,12 +10,6 @@
 <body>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="reminders-root"></div>
-  <!--
-    In a real build, the script src would be the bundled JS file.
-    For this environment, we'd need a way to reference the compiled remindersApp.tsx.
-    This is a placeholder to indicate where it would go.
-  -->
-
-  <!-- Or, if using a bundler: <script src="/static/js/bundle.js"></script> -->
+  <script type="module" src="/dist/remindersApp.js"></script>
 </body>
 </html>


### PR DESCRIPTION
calendar.html and reminders.html were previously blank because they were not loading their respective JavaScript applications.

This commit updates both HTML files to include <script> tags that reference the compiled JavaScript bundles (assumed to be in `/dist/calendarApp.js` and `/dist/remindersApp.js`). This allows the React components for the calendar and reminders to be rendered, making these pages functional when you navigate to them.